### PR TITLE
fix(button): add width 100% to button__text element

### DIFF
--- a/common.blocks/button/button.post.css
+++ b/common.blocks/button/button.post.css
@@ -40,6 +40,7 @@
     position: relative;
     display:  inline-block;
 
+    width: 100%;
     overflow: hidden;
     text-overflow:  ellipsis;
     vertical-align: middle;


### PR DESCRIPTION
добавил `width: 100%` для элемента `text` блока `button`, для возможности скрывать текст за троеточием, когда он выходит за рамки блока:
![2016-03-21 16 26 54](https://cloud.githubusercontent.com/assets/6027846/13933593/6b9dad00-efc7-11e5-9bbf-6cf2a3f34f2f.png)

Сейчас это выглядит так:
![2016-03-21 16 35 11](https://cloud.githubusercontent.com/assets/6027846/13933578/50bdc718-efc7-11e5-80c3-6dcdf48845a2.png)